### PR TITLE
Update python_sdk_examples.ipynb

### DIFF
--- a/python_sdk_examples.ipynb
+++ b/python_sdk_examples.ipynb
@@ -261,7 +261,7 @@
     "        print(f\"No Records Found for the Topic: {topic}\")\n",
     "              \n",
     "    for message in messages:\n",
-    "        print(f\"value :\")"
+    "        print(f\"value :\")",
     "        print(message.value())"
    ],
    "outputs": [


### PR DESCRIPTION
The notebook file had a JSON compilation error, making it impossible to open and view on a system. It turned out to be a missing comma, which could only be identified by running the .ipynb file through a JSON validator and compiling it to find the error. This is a tedious task, and I believe correcting it would save time for many people.

Thank you.